### PR TITLE
Make the crate compile with rust-lang/rust#97346

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -97,7 +97,7 @@ impl Router {
         http::Request<Body>,
         Response = http::Response<Body>,
         Error = Infallible,
-        Future = impl Send,
+        Future = impl Future<Output = Result<http::Response<Body>, Infallible>> + Send + 'static,
     > + Clone {
         let this = Arc::new(self);
         service_fn(move |request: http::Request<Body>| this.clone().handle(request).never_error())


### PR DESCRIPTION
Context: https://github.com/rust-lang/rust/pull/97346 will remove a back-compatibility hack and we've found this crate no longer compiles after that change by [crater](https://github.com/rust-lang/crater#readme). This patch fixes it.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>